### PR TITLE
Bump govuk-frontend

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -50,7 +50,7 @@ lazy val itServer = (project in file("it-server"))
     libraryDependencies ++= PlayCrossCompilation.dependencies(
       shared = Seq(
         filters,
-        "org.webjars.npm" % "govuk-frontend" % "1.0.0",
+        "org.webjars.npm" % "govuk-frontend" % "3.3.0",
         "org.scalactic" %% "scalactic" % "3.0.7" % "test",
         "org.scalatest" %% "scalatest" % "3.0.7" % "test",
         "org.scalacheck" %% "scalacheck" % "1.14.0" % "test",
@@ -62,7 +62,7 @@ lazy val itServer = (project in file("it-server"))
       )
     ),
     Concat.groups := Seq(
-      "javascripts/application.js" -> group(Seq("lib/govuk-frontend/all.js"))
+      "javascripts/application.js" -> group(Seq("lib/govuk-frontend/govuk/all.js"))
     ),
     pipelineStages in Assets := Seq(concat, uglify),
     coverageEnabled := false

--- a/it-server/app/assets/stylesheets/application-ie8.scss
+++ b/it-server/app/assets/stylesheets/application-ie8.scss
@@ -1,3 +1,3 @@
-$govuk-assets-path: "/public/lib/govuk-frontend/assets/";
+$govuk-assets-path: "/public/lib/govuk-frontend/govuk/assets/";
 
-@import "lib/govuk-frontend/all-ie8.scss"
+@import "lib/govuk-frontend/govuk/all-ie8.scss"

--- a/it-server/app/assets/stylesheets/application.scss
+++ b/it-server/app/assets/stylesheets/application.scss
@@ -1,3 +1,3 @@
-$govuk-assets-path: "/public/lib/govuk-frontend/assets/";
+$govuk-assets-path: "/public/lib/govuk-frontend/govuk/assets/";
 
-@import "lib/govuk-frontend/all"
+@import "lib/govuk-frontend/govuk/all"

--- a/it-server/conf/common.conf
+++ b/it-server/conf/common.conf
@@ -5,6 +5,6 @@ nunjucks {
   ]
 
   libPaths: [
-    "govuk-frontend/components"
+    "govuk-frontend"
   ]
 }

--- a/it-server/conf/views/includes/layout.njk
+++ b/it-server/conf/views/includes/layout.njk
@@ -1,5 +1,5 @@
-{% extends "govuk-frontend/template.njk" %}
-{%- set assetPath = "/public/lib/govuk-frontend/assets" -%}
+{% extends "govuk/template.njk" %}
+{%- set assetPath = "/public/lib/govuk-frontend/govuk/assets" -%}
 
 {% block head %}
   {% include "includes/head.njk" %}

--- a/it-server/conf/views/question.njk
+++ b/it-server/conf/views/question.njk
@@ -1,9 +1,9 @@
 {% extends "includes/layout.njk" %}
 
-{% from "back-link/macro.njk"     import govukBackLink %}
-{% from "input/macro.njk"         import govukInput %}
-{% from "button/macro.njk"        import govukButton %}
-{% from "error-summary/macro.njk" import govukErrorSummary %}
+{% from "govuk/components/back-link/macro.njk"     import govukBackLink %}
+{% from "govuk/components/input/macro.njk"         import govukInput %}
+{% from "govuk/components/button/macro.njk"        import govukButton %}
+{% from "govuk/components/error-summary/macro.njk" import govukErrorSummary %}
 
 {% block content %}
 

--- a/it-server/project/build.properties
+++ b/it-server/project/build.properties
@@ -1,0 +1,1 @@
+sbt.version=0.13.17


### PR DESCRIPTION
Note: this is a breaking change as govuk-frontend is prefixing the namespaces
for components with `gouvk`.