### PR TITLE
Uplift nunjucks version to v3.2.4

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,4 +1,5 @@
 {
+  "name": "play-nunjucks",
   "requires": true,
   "lockfileVersion": 1,
   "dependencies": {
@@ -34,7 +35,7 @@
     "asap": {
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
-      "integrity": "sha1-5QNHYR1+aQlDIIu9r+vLwvuGbUY="
+      "integrity": "sha512-BSHWgDSAiKs50o2Re8ppvp3seVHXSRM44cdSsT9FfNEUUZLOGWVCsiWaRPWM1Znn+mqZ1OfVZ3z3DWEzSp7hRA=="
     },
     "astral-regex": {
       "version": "2.0.0",
@@ -113,9 +114,9 @@
       "integrity": "sha512-jttmRe7bRse52OsWIMDLaXxWqRAmtIUccAQ3garviCqJjafXOfNMO0yMfNpdD6zbGaTU0P5Nz7e7gAT6cKmJRw=="
     },
     "nunjucks": {
-      "version": "3.2.3",
-      "resolved": "https://registry.npmjs.org/nunjucks/-/nunjucks-3.2.3.tgz",
-      "integrity": "sha512-psb6xjLj47+fE76JdZwskvwG4MYsQKXUtMsPh6U0YMvmyjRtKRFcxnlXGWglNybtNTNVmGdp94K62/+NjF5FDQ==",
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/nunjucks/-/nunjucks-3.2.4.tgz",
+      "integrity": "sha512-26XRV6BhkgK0VOxfbU5cQI+ICFUtMLixv1noZn1tGU38kQH5A5nmmbk/O45xdyBhD1esk47nKrY0mvQpZIhRjQ==",
       "requires": {
         "a-sync-waterfall": "^1.0.0",
         "asap": "^2.0.3",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
     "audit": "better-npm-audit audit"
   },
   "dependencies": {
-    "nunjucks": "^3.1.3",
+    "nunjucks": "^3.2.4",
     "better-npm-audit": "^3.7.3"
   }
 }


### PR DESCRIPTION
Following the audit's identification of a vulnerability in the current version of the nunjucks library, I have opted to upgrade to a patched version. This newer version addresses and resolves the XSS issue previously present.

https://github.com/advisories/GHSA-x77j-w7wf-fjmw