### PR TITLE
PLATUI-3027 add README regarding old node version

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,11 @@ target/
 node_modules/
 .bsp/
 .DS_Store
+.metals/
+.vscode/
+project/.bloop/
+project/metals.sbt
+project/project/
 play-nunjucks-play-28/package.json
 play-nunjucks-play-28/package-lock.json
 play-nunjucks-play-29/package.json

--- a/README.md
+++ b/README.md
@@ -287,3 +287,8 @@ service and there may be further edge cases that this solution does not cover.
 If your service has a high number of routes and experiences this or a related issue, it's worth
 considering whether it's possible to reduce the number of routes via consolidation or potentially
 split the frontend microservice into multiple microservices.
+
+## Node Version
+The Node version is set in nvmrc at `8.12.0`. This is an old version of Node, however upgrading the version of Node isn't a trivial process, as we build this project in Play 2.8, 2.9 and 3.0. Bumping this package is fine for 2.9 and 3.0, but upgrading this in 2.8 isn't as straight-forward due to a dependency of Play, [sbt-js-engine](https://github.com/playframework/playframework/blob/2.8.x/project/Dependencies.scala#L222) which is [bumped in 2.9](https://github.com/playframework/playframework/blob/2.9.x/project/Dependencies.scala#L247) and [3.0](https://github.com/playframework/playframework/blob/3.0.x/project/Dependencies.scala#L225). By default, this runs `npm update` rather than `npm ci`, causing errors on build for 2.8.
+
+Given this, we're deferring the upgrade of the Node version until such a time we can drop support for Play 2.8. This repo uses npm to just pull the relevant packages, so there is no major risk in leaving this on an older version of node.

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -23,6 +23,6 @@ addSbtPlugin("net.ground5hark.sbt" % "sbt-concat" % "0.2.0")
 
 addSbtPlugin("com.typesafe.sbt" % "sbt-uglify" % "2.0.0")
 
-addSbtPlugin("uk.gov.hmrc" % "sbt-auto-build" % "3.20.0")
+addSbtPlugin("uk.gov.hmrc" % "sbt-auto-build" % "3.21.0")
 
 addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.4.0")


### PR DESCRIPTION
# Purpose of PR
Node cannot be updated past about `10.24.1`, due to a [dependency of Play](https://github.com/playframework/playframework/blob/2.8.x/project/Dependencies.scala#L222). This fails on 2.8, but was bumped in 2.9 and 3.0. Given the effort required, added a small block in the README to explain why we won't upgrade it right now.